### PR TITLE
Statically link to `libc6`

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -23,7 +23,15 @@ parts:
     source-type: git
     build-snaps:
       - go
+    build-packages:
+      - libc6-dev
     plugin: go
+    build-environment:
+      # Statically link libc so the binary is portable across glibc versions.
+      # CGO is required (main.go uses import "C" for a pre-runtime namespace
+      # unshare), so `CGO_ENABLED=0`` is not an option; statically linking is
+      # used instead to avoid a runtime dependency on the host's libc.so.6.
+      - GOFLAGS: "-ldflags=-extldflags=-static"
 
   strip:
     after:

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -35,7 +35,3 @@ parts:
       # Strip binaries
       find "${CRAFT_PRIME}"/bin -type f \
         -exec strip -s {} +
-
-lint:
-  ignore:
-    - library  # classic snaps don't need to bundle any library as they use the host's libraries


### PR DESCRIPTION
After switching to a `base: bare`, the linter complained:

```
$ snapcraft pack                                            
Version has been set to '0+git.78d3e63'
Version has been set to '0+git.78d3e63'
Lint warnings:
- library: bin/lxd-imagebuilder: missing dependency 'libc.so.6'. (provided by 'libc6') (https://documentation.ubuntu.com/snapcraft/stable/how-to/debugging/use-the-library-linter)
- library: bin/simplestream-maintainer: missing dependency 'libc.so.6'. (provided by 'libc6') (https://documentation.ubuntu.com/snapcraft/stable/how-to/debugging/use-the-library-linter)
```

Even then, it worked on 22.04 and 24.04 hosts but it's safer to properly statically link to the `libc6` for safety.